### PR TITLE
Add a `verbose` option to our parser

### DIFF
--- a/diddiparser2/cli.py
+++ b/diddiparser2/cli.py
@@ -17,6 +17,14 @@ def get_parser():
         dest="ignore_suffix",
         help="Ignore the suffix warnings from the parser.",
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        default=False
+        action="store_true",
+        dest="verbose",
+        help="Run the code on verbose mode."
+    )
     return parser
 
 
@@ -25,7 +33,11 @@ def main():
     options = parser.parse_args()
     if not options.file:
         parser.error("No such 'file' specified to run")
-    script = DiddiParser(options.file, ignore_suffix=options.ignore_suffix)
+    script = DiddiParser(
+        options.file,
+        ignore_suffix=options.ignore_suffix,
+        verbose=options.verbose,
+    )
     script.runfile()
 
 

--- a/diddiparser2/cli.py
+++ b/diddiparser2/cli.py
@@ -23,7 +23,7 @@ def get_parser():
         default=False,
         action="store_true",
         dest="verbose",
-        help="Run the code on verbose mode."
+        help="Run the code on verbose mode.",
     )
     return parser
 

--- a/diddiparser2/cli.py
+++ b/diddiparser2/cli.py
@@ -20,7 +20,7 @@ def get_parser():
     parser.add_argument(
         "-v",
         "--verbose",
-        default=False
+        default=False,
         action="store_true",
         dest="verbose",
         help="Run the code on verbose mode."

--- a/diddiparser2/parser.py
+++ b/diddiparser2/parser.py
@@ -73,7 +73,7 @@ class DiddiParser:
 
     last_value = None
 
-    def __init__(self, file, strategy=io.open, ignore_suffix=False):
+    def __init__(self, file, strategy=io.open, ignore_suffix=False, verbose=False):
         "Constructor method."
         if not file.endswith(".diddi") and not ignore_suffix:
             show_warning(
@@ -84,6 +84,7 @@ class DiddiParser:
             )
         self.script = strategy(file)
         self.commands = self.get_commands()
+        self.verbose = verbose
 
     def get_commands(self):
         "Get the commands from our script."
@@ -101,7 +102,10 @@ class DiddiParser:
     def runfile(self):
         "Run the parsed file."
         for line in self.commands:
-            self.print_command(line)
+            if self.verbose:
+                # Verbose mode, so we should
+                # print the command introduced
+                self.print_command(line)
             self.executeline(line)
         success_message()
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -13,8 +13,8 @@ script:
     diddiparser2 file.diddi
 
 
-Options
--------
+``diddiparser2`` options
+------------------------
 
 ``--version``
 ^^^^^^^^^^^^^
@@ -23,23 +23,34 @@ Options
 
     diddiparser2 --version
 
-Print the parser version.
+Print the parser's version.
 
 ``--ignore-suffix``
 ^^^^^^^^^^^^^^^^^^^
 
 ::
 
-    diddiparser2 --ignore-suffix other_script.txt
+    diddiparser2 other_script.txt --ignore-suffix
 
 Ignore the warnings caused when the script does not end with the standard
-``.diddi`` prefix.
+``.diddi`` prefix. This passes ``ignore_suffix=True`` to
+:py:meth:`diddiparser2.parser.DiddiParser.__init__`.
 
-Interactive console
--------------------
+``--verbose``
+^^^^^^^^^^^^^
 
-DiddiParser has provided an interactive console to run command-by-command,
-via the ``diddiscript-console`` command:
+::
+
+    diddiparser2 some_file.diddi --verbose
+
+Pass ``verbose=True`` to :py:meth:`diddiparser2.parser.DiddiParser.__init__`. The
+parser will echo all the commands found in the file.
+
+``diddiscript-console`` -- Interactive console
+----------------------------------------------
+
+DiddiParser 2 has provided an interactive console to run command-by-command
+(which is, formally, a REPL), via the ``diddiscript-console`` command:
 
 ::
 
@@ -50,4 +61,3 @@ via the ``diddiscript-console`` command:
     ============================================================
 
     >
-```

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -13,6 +13,12 @@ some useful variables.
 
 .. py:module:: diddiparser2.parser
 
+.. py:data:: __version__
+
+   :type: str
+
+   A string that represents the parser's version.
+
 .. py:data:: TOOL_FUNCTIONS
 
    :type: tuple
@@ -39,11 +45,12 @@ some useful variables.
 
    This class is the main DiddiScript parser.
 
-   .. py:method:: __init__(self, file)
-                  __init__(self, file, ignore_suffix=False)
+   .. py:method:: __init__(self, file, ignore_suffix=False, verbose=False)
 
       :param str file: The DiddiScript file to be parsed.
-      :param bool ignore_suffix: If ``True``, tells DiddiParser to ignore the suffix mismatch.
+      :param bool ignore_suffix: If True, tells DiddiParser to ignore the suffix mismatch.
+      :param bool verbose: If True, the parser will echo all the commands
+                           executed by :py:meth:`diddiparser2.parser.DiddiParser.runfile`.
 
       The constructor method. It reads the selected filename, and gets the commands via
       :py:meth:`diddiparser2.parser.DiddiParser.get_commands`.


### PR DESCRIPTION
Sometimes, we don't want all the information when parsing.

TODO:

- [x] Add the option to the parser
- [x] Enable the option at the CLI (`diddiparser2`, `python -m diddiparser2`)
- [x] Document the new changes