### PR TITLE
Add a `compile_only` option to our parser

### DIFF
--- a/diddiparser2/cli.py
+++ b/diddiparser2/cli.py
@@ -25,6 +25,14 @@ def get_parser():
         dest="verbose",
         help="Run the code on verbose mode.",
     )
+    parser.add_argument(
+        "-c",
+        "--compile-only",
+        default=False,
+        action="store_true",
+        dest="compile_only",
+        help="Just compile the code, with minimal executions.",
+    )
     return parser
 
 
@@ -37,6 +45,7 @@ def main():
         options.file,
         ignore_suffix=options.ignore_suffix,
         verbose=options.verbose,
+        compile_only=options.compile_only,
     )
     script.runfile()
 

--- a/diddiparser2/parser.py
+++ b/diddiparser2/parser.py
@@ -73,7 +73,14 @@ class DiddiParser:
 
     last_value = None
 
-    def __init__(self, file, strategy=io.open, ignore_suffix=False, verbose=False):
+    def __init__(
+        self,
+        file,
+        strategy=io.open,
+        ignore_suffix=False,
+        verbose=False,
+        compile_only=True,
+    ):
         "Constructor method."
         if not file.endswith(".diddi") and not ignore_suffix:
             show_warning(
@@ -85,6 +92,7 @@ class DiddiParser:
         self.script = strategy(file)
         self.commands = self.get_commands()
         self.verbose = verbose
+        self.compile_only = compile_only
 
     def get_commands(self):
         "Get the commands from our script."
@@ -184,11 +192,14 @@ class DiddiParser:
         if call in MODULE_FUNCTIONS.keys():
             func = MODULE_FUNCTIONS[call]
             try:
-                self.last_value = func(arg)
+                if not self.compile_only:
+                    self.last_value = func(arg)
                 return None
             except Exception:
                 self.last_value = None
         elif call == "cd" or call == "chdir":
+            if self.compile_only:
+                return None
             os.chdir(arg)
             self.last_value = arg
         elif call == "load_module":
@@ -225,6 +236,8 @@ class DiddiParser:
             self.last_value = None
         elif call == "print_available_functions":
             # Print the available functions
+            if self.compile_only:
+                return None
             if arg:
                 show_warning("This function is not currently accepting arguments.")
             print("---- Special functions ----")

--- a/diddiparser2/parser.py
+++ b/diddiparser2/parser.py
@@ -79,7 +79,7 @@ class DiddiParser:
         strategy=io.open,
         ignore_suffix=False,
         verbose=False,
-        compile_only=True,
+        compile_only=False,
     ):
         "Constructor method."
         if not file.endswith(".diddi") and not ignore_suffix:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -36,8 +36,8 @@ Ignore the warnings caused when the script does not end with the standard
 ``.diddi`` prefix. This passes ``ignore_suffix=True`` to
 :py:meth:`diddiparser2.parser.DiddiParser.__init__`.
 
-``--verbose``
-^^^^^^^^^^^^^
+``--verbose`` / ``-v``
+^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
@@ -45,6 +45,17 @@ Ignore the warnings caused when the script does not end with the standard
 
 Pass ``verbose=True`` to :py:meth:`diddiparser2.parser.DiddiParser.__init__`. The
 parser will echo all the commands found in the file.
+
+``--compile-only`` / ``-c``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    diddiparser2 some_file.diddi --compile-only
+
+Pass ``compile_only=True`` to :py:meth:`diddiparser2.parser.DiddiParser.__init__`.
+The parser will just run what is necessary, and will compile and identify potential
+errors.
 
 ``diddiscript-console`` -- Interactive console
 ----------------------------------------------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -45,12 +45,16 @@ some useful variables.
 
    This class is the main DiddiScript parser.
 
-   .. py:method:: __init__(self, file, ignore_suffix=False, verbose=False)
+   .. py:method:: __init__(self, file, ignore_suffix=False, verbose=False, compile_only=False)
 
       :param str file: The DiddiScript file to be parsed.
       :param bool ignore_suffix: If True, tells DiddiParser to ignore the suffix mismatch.
       :param bool verbose: If True, the parser will echo all the commands
                            executed by :py:meth:`diddiparser2.parser.DiddiParser.runfile`.
+      :param bool compile_only: If True, the parser will just run what is necessary for
+                                compiling (like library loaders and variable definitions),
+                                and will try to find potential errors (unresolved references,
+                                invalid code, etc.).
 
       The constructor method. It reads the selected filename, and gets the commands via
       :py:meth:`diddiparser2.parser.DiddiParser.get_commands`.


### PR DESCRIPTION
Closes #31. Just run when one of these cases are found:

- Module/extension loaders
- Variable definitions, to ensure they are defined well and without warnings
- String indexes, to fail when an impossible reference is found

Also, add this option to the CLI.