### PR TITLE
Use custom types for DiddiScript types

### DIFF
--- a/diddiparser2/diddiscript_types.py
+++ b/diddiparser2/diddiscript_types.py
@@ -4,7 +4,7 @@ Collector for the "standard variables" described by DSGP 1.
 
 from diddiparser2.messages import show_warning
 
-__all__ = ("diddiscript_types_list")
+__all__ = "diddiscript_types_list"
 
 
 class DiddiScriptType:
@@ -49,8 +49,8 @@ class Boolean(DiddiScriptType):
             # This weird expression will help us to
             # identify a "boolean value", even when it is incorrect.
             show_warning(
-              f"No valid DiddiScript boolean values were found for '{value_text}'. "
-              "A truthy-falsy result will be stored instead."
+                f"No valid DiddiScript boolean values were found for '{value_text}'. "
+                "A truthy-falsy result will be stored instead."
             )
             self.value = (not self.value) is False
 
@@ -64,5 +64,6 @@ class Null(DiddiScriptType):
 
     def __str__(self):
         return "Null"
+
 
 diddiscript_types_list = (Integer, Floating, Text, Boolean, Null)

--- a/diddiparser2/diddiscript_types.py
+++ b/diddiparser2/diddiscript_types.py
@@ -1,0 +1,68 @@
+"""
+Collector for the "standard variables" described by DSGP 1.
+"""
+
+from diddiparser2.messages import show_warning
+
+__all__ = ("diddiscript_types_list")
+
+
+class DiddiScriptType:
+    "Template class."
+    value = object()
+
+    def __str__(self):
+        return str(self.value)
+
+
+class Integer(DiddiScriptType):
+    "Integer, natural numbers."
+
+    def __init__(self, value_text):
+        self.value = int(value_text)
+
+
+class Floating(DiddiScriptType):
+    "Floating (decimal) numbers."
+
+    def __init__(self, value_text):
+        self.value = float(value_text)
+
+
+class Text(DiddiScriptType):
+    "Simple text."
+
+    def __init__(self, value_text):
+        self.value = value_text  # we expect this to be a string
+
+    def __str__(self):
+        return self.value
+
+
+class Boolean(DiddiScriptType):
+    "True or False."
+
+    def __init__(self, value_text):
+        if value_text in ("True", "False"):
+            self.value = bool(value_text)
+        else:
+            # This weird expression will help us to
+            # identify a "boolean value", even when it is incorrect.
+            show_warning(
+              f"No valid DiddiScript boolean values were found for '{value_text}'. "
+              "A truthy-falsy result will be stored instead."
+            )
+            self.value = (not self.value) is False
+
+
+class Null(DiddiScriptType):
+    "Nothing to store here!"
+
+    def __init__(self, value_text):
+        # we won't care for 'value_text' now.
+        self.value = None
+
+    def __str__(self):
+        return "Null"
+
+diddiscript_types_list = (Integer, Floating, Text, Boolean, Null)

--- a/diddiparser2/diddiscript_types.py
+++ b/diddiparser2/diddiscript_types.py
@@ -4,7 +4,7 @@ Collector for the "standard variables" described by DSGP 1.
 
 from diddiparser2.messages import show_warning
 
-__all__ = "diddiscript_types_list"
+__all__ = ["diddiscript_types_list"]
 
 
 class DiddiScriptType:
@@ -58,7 +58,7 @@ class Boolean(DiddiScriptType):
 class Null(DiddiScriptType):
     "Nothing to store here!"
 
-    def __init__(self, value_text):
+    def __init__(self, value_text=None):
         # we won't care for 'value_text' now.
         self.value = None
 
@@ -66,4 +66,13 @@ class Null(DiddiScriptType):
         return "Null"
 
 
-diddiscript_types_list = (Integer, Floating, Text, Boolean, Null)
+diddiscript_types_list = {
+    "int": Integer,
+    "float": Floating,
+    "str": Text,
+    "bool": Boolean,
+    "None": Null,
+}
+
+for ds_type in diddiscript_types_list.values():
+    __all__.append(ds_type)

--- a/diddiparser2/parser.py
+++ b/diddiparser2/parser.py
@@ -8,6 +8,7 @@ import os
 import sys
 
 from diddiparser2 import messages
+from diddiparser2.diddiscript_types import Boolean, Floating, Integer, Null, Text
 from diddiparser2.messages import compile_error, show_warning, success_message
 
 __version__ = "1.0.0"
@@ -43,23 +44,23 @@ def identify_value(value):
     if "'" in value or '"' in value:
         # A piece of text, just return
         if value == "''" or value == '""':
-            return ""
-        return value[1:-1]
+            return Text("")
+        return Text(value[1:-1])
     elif value in ("True", "False"):
         # A boolean
-        return bool(value)
+        return Boolean(value)
     elif value == "Null":
         # An empty space
-        return None
+        return Null()
     else:
         # The last possible values are
         # floats and integers
         try:
             if "." in value:
                 # A floating number
-                return float(value.strip())
+                return Floating(value.strip())
             # Maybe an integer?
-            return int(value.strip())
+            return Integer(value.strip())
         except Exception:
             # It failed, so we raise an error
             compile_error(f"Could not identify value: {value}")

--- a/diddiparser2/parser.py
+++ b/diddiparser2/parser.py
@@ -9,7 +9,12 @@ import sys
 
 from diddiparser2 import messages
 from diddiparser2.diddiscript_types import Boolean, Floating, Integer, Null, Text
-from diddiparser2.messages import compile_error, show_warning, success_message
+from diddiparser2.messages import (
+    compile_error,
+    show_command,
+    show_warning,
+    success_message,
+)
 
 __version__ = "1.0.0"
 
@@ -121,8 +126,6 @@ class DiddiParser:
     def print_command(self, cmd):
         "By default, we use the fancy `messages.show_command`"
         # Show the command
-        from diddiparser2.messages import show_command
-
         show_command(cmd)
 
     def executeline(self, line):

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,6 @@ def format(session):
     session.install("-r", "tests/requirements.txt")
     session.run("isort", ".")
     session.run("black", ".")
-    session.log("To get sure both formatters are happy, run 'nox -s lint'.")
 
 
 @nox.session(name="format-and-lint")
@@ -35,14 +34,11 @@ def format_and_lint(session):
     linters have a conflict with another
     linter.
     """
-    session.warn(
-        "We'll run formatters and linters together. "
-        "However, conflicts between linters may be caused by this session."
-    )
+    session.log("Running formatters...")
     session.install("--upgrade", "nox")
     session.log("Formatting...")
     session.run("nox", "-s", "format")
-    session.log("Running linters (this part of the session may cause conflicts).")
+    session.log("Running linters...")
     session.run("nox", "-s", "lint")
     session.log("It seems like everything succeeded!")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,11 @@
 license_file = LICENSE.txt
 
 [flake8]
-# define the flake8 configurations
+# Define the flake8 configurations
 exclude = .nox/
 max-line-length = 127
+
+[isort]
+# Set the profile to black, to get
+# rid of the formatter-vs-formatter issues
+profile = black


### PR DESCRIPTION
Toward #38. The types follow DSGP 1, and won't be treated like Python built-in types anymore.