### PR TITLE
Break the linters and the tests into two CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,16 @@ env:
   FORCE_COLOR: "1"
 
 jobs:
-  build:
-
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.9
     - name: Display Python version
       run: python -c "import sys; print('Python version:', sys.version)"
     - name: Install pip dependencies
@@ -32,8 +29,27 @@ jobs:
     - name: Run linters with Nox
       run: |
         nox --non-interactive -s lint
+
+  tests:
+    name: Tests
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Display Python version
+      run: python -c "import sys; print('Python version:', sys.version)"
+    - name: Install pip dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools nox
     - name: Run DiddiScript tests with Nox
       run: |
         nox --non-interactive -s tests
-    - name: Finalize the test
-      run: echo 'Process completed succesfully!'


### PR DESCRIPTION
The linters doesn't have to run on every Python we support. The tests must run on every OS we support.