### PR TITLE
Fix the `load_extension` bug, and fix the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# TODO: Uncomment this line!
+#lib/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -14,7 +17,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/diddiparser2/lib/_builtin.py
+++ b/diddiparser2/lib/_builtin.py
@@ -4,6 +4,7 @@ A builtin DiddiScript module, to provide libraries by default.
 
 import importlib
 import os
+import sys
 
 from diddiparser2.diddiscript_types import Text
 from diddiparser2.lib import simpleio
@@ -19,6 +20,7 @@ DIDDISCRIPT_FUNCTIONS = (
     "load_extension",
     "print_available_functions",
     "warning",
+    "add_extensions_location",
 )
 MODULE_FUNCTIONS = dict()
 FUNCTIONS_ORIGINS = dict()
@@ -57,6 +59,18 @@ def load_module(*args):
             FUNCTIONS_ORIGINS[item] = ("module", arg)
 
 
+# "add_extensions_location"
+def add_extensions_location(*args):
+    for arg in args:
+        # Add each path-like argument to sys.path...
+        # This function should be used before running
+        # "load_extension", unless the extension's
+        # location is already on PYTHONPATH.
+        arg = str(arg)
+        if os.path.isdir(arg):
+            sys.path.append(arg)
+
+
 # "load_extension"
 def load_extension(*args):
     for arg in args:
@@ -64,7 +78,7 @@ def load_extension(*args):
         # example: "module", "pkg.module"
         arg = str(arg)
         ext = importlib.import_module(f"{arg}")
-        ext_list = ext.DIDDISCRIPT_FUNCTIONS
+        ext_list = ext.DIDDISCRIPT_FUNCTIONS[:]
         for item in ext_list:
             exec(
                 f"from {arg} import {item} as element; MODULE_FUNCTIONS['{item}'] = element",

--- a/diddiparser2/lib/math.py
+++ b/diddiparser2/lib/math.py
@@ -7,15 +7,21 @@ import math
 from diddiparser2.diddiscript_types import Floating, Integer
 from diddiparser2.messages import run_error
 
-DIDDISCRIPT_FUNCTIONS = ["sum_operation", "subtraction_operation", "multiplication_operation", "division_operation", "power"]
+DIDDISCRIPT_FUNCTIONS = [
+    "sum_operation",
+    "subtraction_operation",
+    "multiplication_operation",
+    "division_operation",
+    "power",
+]
 
 
 def check_numbers(*args):
     for arg in args:
         if not isinstance(arg, Floating) and not isinstance(arg, Integer):
             run_error(
-              "Expected Floating or Integer DiddiScript types, "
-              f"but got {type(arg).__name__}"
+                "Expected Floating or Integer DiddiScript types, "
+                f"but got {type(arg).__name__}"
             )
 
 

--- a/diddiparser2/lib/simpleio.py
+++ b/diddiparser2/lib/simpleio.py
@@ -10,7 +10,13 @@ import time
 from diddiparser2.diddiscript_types import Floating, Integer, Text
 from diddiparser2.messages import run_error, show_warning
 
-DIDDISCRIPT_FUNCTIONS = ("program_exit", "print_text", "print_line", "store_input", "wait")
+DIDDISCRIPT_FUNCTIONS = (
+    "program_exit",
+    "print_text",
+    "print_line",
+    "store_input",
+    "wait",
+)
 
 
 def program_exit(msg):
@@ -55,5 +61,7 @@ def wait(amount):
     Both floats and ints are accepted.
     """
     if not isinstance(amount, Floating) and not isinstance(amount, Integer):
-        run_error(f"Expected Floating or Integer types, but got type '{type(amount).__name__}'")
+        run_error(
+            f"Expected Floating or Integer types, but got type '{type(amount).__name__}'"
+        )
     time.sleep(amount.value)

--- a/diddiparser2/lib/sqlite.py
+++ b/diddiparser2/lib/sqlite.py
@@ -8,10 +8,10 @@ from diddiparser2.diddiscript_types import Boolean, Floating, Integer, Null, Tex
 from diddiparser2.messages import run_error, show_warning
 
 DIDDISCRIPT_FUNCTIONS = (
-  "open_database",
-  "close_database",
-  "commit_changes",
-  "execute_sql",
+    "open_database",
+    "close_database",
+    "commit_changes",
+    "execute_sql",
 )
 
 
@@ -43,8 +43,8 @@ class DatabaseStorage:
         if self.connection.in_transaction:
             # some changes will be lost, warn about it
             show_warning(
-              "You tried to close a database with uncommited changes. "
-              "The changes will be lost."
+                "You tried to close a database with uncommited changes. "
+                "The changes will be lost."
             )
         self.cursor.close()
         self.connection.close()
@@ -93,7 +93,9 @@ DATABASE_STORAGE = DatabaseStorage()
 def open_database(path):
     "Open an SQLite database."
     if not isinstance(path, Text):
-        run_error(f"Expected a Text object as 'path', but got type '{type(path).__name__}'.")
+        run_error(
+            f"Expected a Text object as 'path', but got type '{type(path).__name__}'."
+        )
     DATABASE_STORAGE.connect_with_db(str(path))
     return Null()
 
@@ -120,6 +122,6 @@ def execute_sql(*args):
         DATABASE_STORAGE.execute_command(*args)
     except Exception as exc:
         run_error(
-          "The SQLite database connection raised the "
-          f"following error: {str(exc)} ({type(exc).__name__})"
+            "The SQLite database connection raised the "
+            f"following error: {str(exc)} ({type(exc).__name__})"
         )

--- a/docs/language/stdlib/_builtin.rst
+++ b/docs/language/stdlib/_builtin.rst
@@ -99,4 +99,6 @@ Other functions
    :param arg: A text-like path.
 
    This function extends :py:func:`sys.path`, enabling more
-   locations to export extensions.
+   locations to export extensions. It should be used before
+   :py:func:`load_extension`, in case the "extensions file"
+   is not included in :py:func:`sys.path`.

--- a/docs/language/stdlib/_builtin.rst
+++ b/docs/language/stdlib/_builtin.rst
@@ -57,6 +57,12 @@ from other libraries, and load them again by loading ``_builtin``.
    can be imported from the current working directory.
    This function loads as many libraries as you request.
 
+   .. note::
+
+      If the "extensions file" directory is not listed by default
+      on :py:data:`sys.path`, use the :py:func:`add_extensions_location`
+      function first (see below).
+
    .. seealso::
 
        `DSGP 3 <https://github.com/DiddiLeija/diddiparser2/blob/main/dsgp/dsgp-003.md>`_
@@ -84,3 +90,13 @@ found at :doc:`simpleio`.
 .. py:function:: warning(arg)
 
    A shortcut for ``simpleio.warning``.
+
+Other functions
+^^^^^^^^^^^^^^^
+
+.. py:function:: add_extensions_location(arg)
+
+   :param arg: A text-like path.
+
+   This function extends :py:func:`sys.path`, enabling more
+   locations to export extensions.

--- a/tests/test-dsgp3-example.diddi
+++ b/tests/test-dsgp3-example.diddi
@@ -6,6 +6,8 @@
 !# original example is modified, this file should be
 !# updated too.
 
+add_extensions_location(".");  !# This will tell DiddiParser to find extensions here!
+
 load_module("simpleio");
 load_extension("tests.dsgp_3_example");  !# This loads the "tests/dsgp_3_example.py" file
 

--- a/tests/test-lib--builtin.diddi
+++ b/tests/test-lib--builtin.diddi
@@ -7,7 +7,8 @@ load_module("_builtin");
 
 print_line("We can load functions!");
 
-!# ---- load_extension ----
+!# ---- add_extensions_location + load_extension ----
+add_extensions_location(".");
 load_extension("tests.my_extension");
 my_func("abcdef");
 


### PR DESCRIPTION
Closes #151.

This PR fixes a bug with `load_extension`, where modules (the "extensions") couldn't be found. We added an `add_extensions_location` function at the builtins, to extend `sys.path` as a hack to fix the bug.